### PR TITLE
Remove dashes from key identifiers, as those are forbidden by the JMS spec

### DIFF
--- a/opentracing-jms-common/src/main/java/io/opentracing/contrib/jms/common/JmsTextMapInjectAdapter.java
+++ b/opentracing-jms-common/src/main/java/io/opentracing/contrib/jms/common/JmsTextMapInjectAdapter.java
@@ -25,10 +25,17 @@ public class JmsTextMapInjectAdapter implements TextMap {
     @Override
     public void put(String key, String value) {
         try {
-            message.setStringProperty(key, value);
+            // TODO: decide what is the best approach for this mismatch: JMS doesn't allow dashes in the key name
+            message.setStringProperty(cleanForJms(key), value);
         } catch (JMSException e) {
             throw new RuntimeException(e);
         }
+    }
 
+    private String cleanForJms(String key) {
+        if (key == null || key.isEmpty()) {
+            return key;
+        }
+        return key.replaceAll("-", "");
     }
 }

--- a/opentracing-jms-common/src/test/java/io/opentracing/contrib/jms/common/JmsTextMapInjectAdapterTest.java
+++ b/opentracing-jms-common/src/test/java/io/opentracing/contrib/jms/common/JmsTextMapInjectAdapterTest.java
@@ -39,4 +39,11 @@ public class JmsTextMapInjectAdapterTest {
         assertEquals("value2", message.getStringProperty("key2"));
     }
 
+    @Test
+    public void propertyWithDash() throws JMSException {
+        JmsTextMapInjectAdapter adapter = new JmsTextMapInjectAdapter(message);
+        adapter.put("key-1", "value1");
+        assertEquals("value1", message.getStringProperty("key1"));
+    }
+
 }


### PR DESCRIPTION
In the JMS 2.0 spec, section 3.5.1:

> Property names must obey the rules for a message selector identifier. See 
Section 3.8“ Message selection” for more information

and then in section 3.8:

> An identifier is an unlimited -length character sequence that must 
begin with a Java identifier start character; all following characters 
must be Java identifier part characters. An identifier start character 
is any character for which the method Character.isJavaIdentifierStart
returns true. This includes '_' and '$'. An identifier part character is any character 
for which the method Character.isJavaIdentifierPart returns true.

and

> Identifiers are either header field references or property references. 
The type of a property value in a message selector corresponds to 
the type used to set the property. If a property that does not exist in 
a message is referenced, its value is NULL.

One specific example of where this is causing problems is when having the OT-contrib Servlet and OT-contrib JMS as part of the same trace: in some tracers, all HTTP Headers are passed down. Other situation can be seen on the example application [`swarm-jms`][1], which fails with the following exception when using Jaeger:

```
2017-05-04 11:43:42,777 INFO  [io.opentracing.example.swarm.jms.rest.HelloWorldEndpoint] (default task-1) Creating JMS message with content: text
2017-05-04 11:43:42,837 ERROR [org.jboss.as.ejb3.invocation] (default task-1) WFLYEJB0034: EJB Invocation failed on component HelloWorldEndpoint for method public javax.ws.rs.core.Response io.opentracing.example.swarm.jms.rest.HelloWorldEndpoint.doGet(javax.servlet.http.HttpServletRequest) throws javax.jms.JMSException: javax.ejb.EJBException: javax.jms.JMSRuntimeException: AMQ129012: The property name 'uber-trace-id' is not a valid java identifier.
...
...
Caused by: javax.jms.JMSRuntimeException: AMQ129012: The property name 'uber-trace-id' is not a valid java identifier.
	at org.apache.activemq.artemis.jms.client.ActiveMQMessage.checkProperty(ActiveMQMessage.java:862)
	at org.apache.activemq.artemis.jms.client.ActiveMQMessage.setStringProperty(ActiveMQMessage.java:606)
	at io.opentracing.contrib.jms.common.JmsTextMapInjectAdapter.put(JmsTextMapInjectAdapter.java:28)
```

A similar exception happens when using Hawkular APM.

With this patch applied, the linked example shows this on the logs when doing a call to `http://localhost:8080/hello`:

```
2017-05-04 11:40:12,805 INFO  [io.opentracing.example.swarm.jms.rest.HelloWorldEndpoint] (default task-1) Creating JMS message with content: text
2017-05-04 11:40:12,867 INFO  [io.opentracing.example.swarm.jms.rest.HelloWorldEndpoint] (default task-1) JMS message submitted
2017-05-04 11:40:12,881 INFO  [io.opentracing.example.swarm.jms.rest.HelloWorldEndpoint] (Thread-0 (ActiveMQ-client-global-threads-806501318)) Got the following message: text
```

   [1]: https://github.com/jpkrohling/swarm-jms