### PR TITLE
Turned `TracingMessagingMessageListenerAdapter` into a bean

### DIFF
--- a/opentracing-jms-spring/pom.xml
+++ b/opentracing-jms-spring/pom.xml
@@ -71,5 +71,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.21.0</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/opentracing-jms-spring/src/main/java/io/opentracing/contrib/jms/spring/TracingJmsConfiguration.java
+++ b/opentracing-jms-spring/src/main/java/io/opentracing/contrib/jms/spring/TracingJmsConfiguration.java
@@ -33,11 +33,16 @@ public class TracingJmsConfiguration {
   public TracingJmsConfiguration(ObjectProvider<MessageConverter> messageConverter) {
     this.messageConverter = messageConverter;
   }
-  
+
+  @Bean
+  public TracingMessagingMessageListenerAdapter createTracingMessagingMessageListenerAdapter(Tracer tracer) {
+    return new TracingMessagingMessageListenerAdapter(tracer);
+  }
+
   @Bean
   public TracingJmsListenerEndpointRegistry createTracingJmsListenerEndpointRegistry(
-      Tracer tracer) {
-    return new TracingJmsListenerEndpointRegistry(tracer);
+      TracingMessagingMessageListenerAdapter listenerAdapter) {
+    return new TracingJmsListenerEndpointRegistry(listenerAdapter);
   }
 
   @Bean

--- a/opentracing-jms-spring/src/main/java/io/opentracing/contrib/jms/spring/TracingMessagingMessageListenerAdapter.java
+++ b/opentracing-jms-spring/src/main/java/io/opentracing/contrib/jms/spring/TracingMessagingMessageListenerAdapter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.jms.spring;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.jms.common.TracingMessageListener;
+import io.opentracing.contrib.jms.common.TracingMessageUtils;
+import org.springframework.jms.listener.adapter.MessagingMessageListenerAdapter;
+
+import javax.jms.*;
+import java.lang.IllegalStateException;
+
+public class TracingMessagingMessageListenerAdapter extends MessagingMessageListenerAdapter {
+
+    protected Tracer tracer;
+
+    protected TracingMessagingMessageListenerAdapter(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    @Override
+    public void onMessage(final Message jmsMessage, final Session session) throws JMSException {
+        TracingMessageListener listener = new TracingMessageListener(
+            new MessageListener() {
+                @Override
+                public void onMessage(Message message) {
+                    onMessageInternal(message, session);
+                }
+            }, tracer);
+        listener.onMessage(jmsMessage);
+    }
+
+    private void onMessageInternal(Message jmsMessage, Session session) {
+        try {
+            super.onMessage(jmsMessage, session);
+        } catch (JMSException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    protected void sendResponse(Session session, Destination destination, Message response)
+        throws JMSException {
+        Span span = TracingMessageUtils.buildAndInjectSpan(destination, response, tracer);
+        try {
+            super.sendResponse(session, destination, response);
+        } finally {
+            span.finish();
+        }
+    }
+
+    protected TracingMessagingMessageListenerAdapter newInstance() {
+        return new TracingMessagingMessageListenerAdapter(tracer);
+    }
+}

--- a/opentracing-jms-spring/src/main/java/io/opentracing/contrib/jms/spring/TracingMessagingMessageListenerAdapter.java
+++ b/opentracing-jms-spring/src/main/java/io/opentracing/contrib/jms/spring/TracingMessagingMessageListenerAdapter.java
@@ -19,8 +19,11 @@ import io.opentracing.contrib.jms.common.TracingMessageListener;
 import io.opentracing.contrib.jms.common.TracingMessageUtils;
 import org.springframework.jms.listener.adapter.MessagingMessageListenerAdapter;
 
-import javax.jms.*;
-import java.lang.IllegalStateException;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.Session;
 
 public class TracingMessagingMessageListenerAdapter extends MessagingMessageListenerAdapter {
 

--- a/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/ExtendedTracingMessagingMessageListenerAdapter.java
+++ b/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/ExtendedTracingMessagingMessageListenerAdapter.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.jms.spring;
 
 import io.opentracing.Tracer;

--- a/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/ExtendedTracingMessagingMessageListenerAdapter.java
+++ b/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/ExtendedTracingMessagingMessageListenerAdapter.java
@@ -1,0 +1,37 @@
+package io.opentracing.contrib.jms.spring;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.jms.common.TracingMessageListener;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.Session;
+
+public class ExtendedTracingMessagingMessageListenerAdapter extends TracingMessagingMessageListenerAdapter {
+
+    protected ExtendedTracingMessagingMessageListenerAdapter(Tracer tracer) {
+        super(tracer);
+    }
+
+    @Override
+    public void onMessage(final Message jmsMessage, final Session session) {
+        TracingMessageListener listener = new TracingMessageListener(
+            new MessageListener() {
+                @Override
+                public void onMessage(Message message) {
+                    try {
+                        jmsMessage.acknowledge();
+                    } catch (JMSException e) {
+
+                    }
+                }
+            }, tracer);
+        listener.onMessage(jmsMessage);
+    }
+
+    @Override
+    protected TracingMessagingMessageListenerAdapter newInstance() {
+        return new ExtendedTracingMessagingMessageListenerAdapter(tracer);
+    }
+}

--- a/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/TestConfiguration.java
+++ b/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/TestConfiguration.java
@@ -13,6 +13,7 @@
  */
 package io.opentracing.contrib.jms.spring;
 
+import io.opentracing.Tracer;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.mock.MockTracer.Propagator;
 import io.opentracing.util.ThreadLocalScopeManager;
@@ -21,6 +22,7 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.jms.annotation.EnableJms;
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
 import org.springframework.jms.support.converter.MessageConverter;
@@ -47,6 +49,12 @@ public class TestConfiguration {
   @Bean
   public DestinationResolver destinationResolver() {
     return new DynamicDestinationResolver();
+  }
+
+  @Bean
+  @Primary
+  public TracingMessagingMessageListenerAdapter tracingMessagingMessageListenerAdapter(Tracer tracer) {
+    return new ExtendedTracingMessagingMessageListenerAdapter(tracer);
   }
 
   @Bean

--- a/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/TestConfiguration.java
+++ b/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/TestConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.jms.annotation.EnableJms;
 import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
 import org.springframework.jms.support.converter.MessageConverter;
@@ -53,6 +54,7 @@ public class TestConfiguration {
 
   @Bean
   @Primary
+  @Profile("extended")
   public TracingMessagingMessageListenerAdapter tracingMessagingMessageListenerAdapter(Tracer tracer) {
     return new ExtendedTracingMessagingMessageListenerAdapter(tracer);
   }

--- a/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/TracingMessagingMessageListenerAdapterTest.java
+++ b/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/TracingMessagingMessageListenerAdapterTest.java
@@ -1,0 +1,43 @@
+package io.opentracing.contrib.jms.spring;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {TestConfiguration.class})
+public class TracingMessagingMessageListenerAdapterTest {
+
+    @Autowired
+    private TracingMessagingMessageListenerAdapter adapter;
+
+    @Mock
+    private Message jmsMessage;
+
+    @Before
+    public void before() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testExtendedAdapterCreatesCorrectInstance() {
+        TracingMessagingMessageListenerAdapter instance = adapter.newInstance();
+        Assert.assertTrue(instance instanceof ExtendedTracingMessagingMessageListenerAdapter);
+    }
+
+    @Test
+    public void testExtendedAdapterHandlesMessage() throws JMSException {
+        adapter.onMessage(jmsMessage, null);
+        Mockito.verify(jmsMessage, Mockito.times(1)).acknowledge();
+    }
+}

--- a/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/TracingMessagingMessageListenerAdapterTest.java
+++ b/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/TracingMessagingMessageListenerAdapterTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.jms.spring;
 
 import org.junit.Assert;
@@ -8,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -15,6 +29,7 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 
 @RunWith(SpringRunner.class)
+@ActiveProfiles("extended")
 @ContextConfiguration(classes = {TestConfiguration.class})
 public class TracingMessagingMessageListenerAdapterTest {
 


### PR DESCRIPTION
Now `TracingMessagingMessageListenerAdapter` can be extended by anyone who wishes to change the message handling logic, and catch & log any exceptions.

At first I wanted to make `TracingMessageListener` into a bean, but since it's located in `common`, spring is not in dependencies there, so I left it alone.

Regarding `TracingMessagingMessageListenerAdapter.newInstance()` - I'm not sure if this is needed or not, but since the name of `TracingJmsListenerEndpointRegistry.TracingMethodJmsListenerEndpoint.createMessageListenerInstance()` implies that it requires a new _instance_ of the listener adapter, I've made it to receive a new instance of the bean instead of the bean itself. If someone thinks it can just be passed the original bean, then I can change it back.