### PR TITLE
Set scope=provided

### DIFF
--- a/opentracing-jms-1/pom.xml
+++ b/opentracing-jms-1/pom.xml
@@ -52,6 +52,13 @@
     </dependency>
 
     <dependency>
+      <groupId>javax.jms</groupId>
+      <artifactId>jms-api</artifactId>
+      <version>1.1-rev-1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>activemq-broker</artifactId>
       <version>${activemq.version}</version>

--- a/opentracing-jms-2/pom.xml
+++ b/opentracing-jms-2/pom.xml
@@ -49,18 +49,13 @@
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-jms-common</artifactId>
       <version>0.1.7-SNAPSHOT</version>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.jms</groupId>
-          <artifactId>jms-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
       <groupId>javax.jms</groupId>
       <artifactId>javax.jms-api</artifactId>
       <version>2.0.1</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/opentracing-jms-common/pom.xml
+++ b/opentracing-jms-common/pom.xml
@@ -32,6 +32,7 @@
       <groupId>javax.jms</groupId>
       <artifactId>jms-api</artifactId>
       <version>1.1-rev-1</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/opentracing-jms-spring/pom.xml
+++ b/opentracing-jms-spring/pom.xml
@@ -39,15 +39,24 @@
     </dependency>
 
     <dependency>
+      <groupId>javax.jms</groupId>
+      <artifactId>javax.jms-api</artifactId>
+      <version>2.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jms</artifactId>
       <version>${spring.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
       <version>${spring.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Setting the scope of the target libraries of instrumentation to "provided". It is a guarantee that the integrating codebase will provide these libraries, otherwise the instrumentation plugin would be moot if the codebase does not already have these libraries.