### PR TITLE
tracer.extract() might return incomplete spancontext

### DIFF
--- a/opentracing-jms-common/src/main/java/io/opentracing/contrib/jms/common/TracingMessageUtils.java
+++ b/opentracing-jms-common/src/main/java/io/opentracing/contrib/jms/common/TracingMessageUtils.java
@@ -74,7 +74,7 @@ public class TracingMessageUtils {
   public static SpanContext extract(Message message, Tracer tracer) {
     SpanContext spanContext =
         tracer.extract(Format.Builtin.TEXT_MAP, new JmsTextMapExtractAdapter(message));
-    if (spanContext != null) {
+    if (spanContext != null && spanContext.toTraceId() != null && spanContext.toSpanId() != null) {
       return spanContext;
     }
 


### PR DESCRIPTION
Make sure that traceId and spanId is set in SpanContext from tracer.extract

BraveTracer will return an incomplete SpanContext where toTraceId()
and toSpanId() both return null instead of a null SpanContext if
the extract did not find any information in the carrier.

This commit verifiers that the returned SpanContext actually
has both trace and span id.