### PR TITLE
Add TracingConnectionFactory, TracingJMSContext and TracingJMSConsumer

### DIFF
--- a/opentracing-jms-2/src/main/java/io/opentracing/contrib/jms2/TracingConnectionFactory.java
+++ b/opentracing-jms-2/src/main/java/io/opentracing/contrib/jms2/TracingConnectionFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.jms2;
+
+import io.opentracing.Tracer;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSContext;
+import javax.jms.JMSException;
+
+/**
+ * Tracing decorator for JMS {@code javax.jms.ConnectionFactory}.
+ */
+public class TracingConnectionFactory implements ConnectionFactory {
+
+  private final ConnectionFactory connectionFactory;
+  private final Tracer tracer;
+
+  public TracingConnectionFactory(ConnectionFactory connectionFactory, Tracer tracer) {
+    this.connectionFactory = connectionFactory;
+    this.tracer = tracer;
+  }
+
+  @Override
+  public Connection createConnection() throws JMSException {
+    return new TracingConnection(connectionFactory.createConnection(), tracer);
+  }
+
+  @Override
+  public Connection createConnection(String userName, String password) throws JMSException {
+    return new TracingConnection(connectionFactory.createConnection(userName, password), tracer);
+  }
+
+  @Override
+  public JMSContext createContext() {
+    return new TracingJMSContext(connectionFactory.createContext(), tracer);
+  }
+
+  @Override
+  public JMSContext createContext(String userName, String password) {
+    return new TracingJMSContext(connectionFactory.createContext(userName, password), tracer);
+  }
+
+  @Override
+  public JMSContext createContext(String userName, String password, int sessionMode) {
+    return new TracingJMSContext(connectionFactory.createContext(userName, password, sessionMode), tracer);
+  }
+
+  @Override
+  public JMSContext createContext(int sessionMode) {
+    return new TracingJMSContext(connectionFactory.createContext(sessionMode), tracer);
+  }
+}

--- a/opentracing-jms-2/src/main/java/io/opentracing/contrib/jms2/TracingJMSConsumer.java
+++ b/opentracing-jms-2/src/main/java/io/opentracing/contrib/jms2/TracingJMSConsumer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.jms2;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.jms.common.TracingMessageListener;
+
+import javax.jms.JMSConsumer;
+import javax.jms.JMSRuntimeException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+
+/**
+ * Tracing decorator for JMS {@code javax.jms.JMSConsumer}.
+ */
+public class TracingJMSConsumer implements JMSConsumer {
+
+  private final JMSConsumer jmsConsumer;
+  private final Tracer tracer;
+
+  public TracingJMSConsumer(JMSConsumer jmsConsumer, Tracer tracer) {
+    this.jmsConsumer = jmsConsumer;
+    this.tracer = tracer;
+  }
+
+  @Override
+  public String getMessageSelector() {
+    return jmsConsumer.getMessageSelector();
+  }
+
+  @Override
+  public MessageListener getMessageListener() throws JMSRuntimeException {
+    return jmsConsumer.getMessageListener();
+  }
+
+  @Override
+  public void setMessageListener(MessageListener listener) throws JMSRuntimeException {
+    jmsConsumer.setMessageListener(new TracingMessageListener(listener, tracer));
+  }
+
+  @Override
+  public Message receive() {
+    return jmsConsumer.receive();
+  }
+
+  @Override
+  public Message receive(long timeout) {
+    return jmsConsumer.receive(timeout);
+  }
+
+  @Override
+  public Message receiveNoWait() {
+    return jmsConsumer.receiveNoWait();
+  }
+
+  @Override
+  public void close() {
+    jmsConsumer.close();
+  }
+
+  @Override
+  public <T> T receiveBody(Class<T> c) {
+    return jmsConsumer.receiveBody(c);
+  }
+
+  @Override
+  public <T> T receiveBody(Class<T> c, long timeout) {
+    return jmsConsumer.receiveBody(c, timeout);
+  }
+
+  @Override
+  public <T> T receiveBodyNoWait(Class<T> c) {
+    return jmsConsumer.receiveBodyNoWait(c);
+  }
+}

--- a/opentracing-jms-2/src/main/java/io/opentracing/contrib/jms2/TracingJMSContext.java
+++ b/opentracing-jms-2/src/main/java/io/opentracing/contrib/jms2/TracingJMSContext.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.jms2;
+
+import io.opentracing.Tracer;
+
+import javax.jms.BytesMessage;
+import javax.jms.ConnectionMetaData;
+import javax.jms.Destination;
+import javax.jms.ExceptionListener;
+import javax.jms.JMSConsumer;
+import javax.jms.JMSContext;
+import javax.jms.JMSProducer;
+import javax.jms.MapMessage;
+import javax.jms.Message;
+import javax.jms.ObjectMessage;
+import javax.jms.Queue;
+import javax.jms.QueueBrowser;
+import javax.jms.StreamMessage;
+import javax.jms.TemporaryQueue;
+import javax.jms.TemporaryTopic;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+import java.io.Serializable;
+
+/**
+ * Tracing decorator for JMS {@code javax.jms.JMSContext}.
+ */
+public class TracingJMSContext implements JMSContext {
+
+  private final JMSContext jmsContext;
+  private final Tracer tracer;
+
+  public TracingJMSContext(JMSContext jmsContext, Tracer tracer) {
+    this.jmsContext = jmsContext;
+    this.tracer = tracer;
+  }
+
+  @Override
+  public JMSContext createContext(int sessionMode) {
+    return new TracingJMSContext(jmsContext.createContext(sessionMode), tracer);
+  }
+
+  @Override
+  public JMSProducer createProducer() {
+    return new TracingJMSProducer(jmsContext.createProducer(), jmsContext, tracer);
+  }
+
+  @Override
+  public String getClientID() {
+    return jmsContext.getClientID();
+  }
+
+  @Override
+  public void setClientID(String clientID) {
+    jmsContext.setClientID(clientID);
+  }
+
+  @Override
+  public ConnectionMetaData getMetaData() {
+    return jmsContext.getMetaData();
+  }
+
+  @Override
+  public ExceptionListener getExceptionListener() {
+    return jmsContext.getExceptionListener();
+  }
+
+  @Override
+  public void setExceptionListener(ExceptionListener listener) {
+    jmsContext.setExceptionListener(listener);
+  }
+
+  @Override
+  public void start() {
+    jmsContext.start();
+  }
+
+  @Override
+  public void stop() {
+    jmsContext.stop();
+  }
+
+  @Override
+  public boolean getAutoStart() {
+    return jmsContext.getAutoStart();
+  }
+
+  @Override
+  public void setAutoStart(boolean autoStart) {
+    jmsContext.setAutoStart(autoStart);
+  }
+
+  @Override
+  public void close() {
+    jmsContext.close();
+  }
+
+  @Override
+  public BytesMessage createBytesMessage() {
+    return jmsContext.createBytesMessage();
+  }
+
+  @Override
+  public MapMessage createMapMessage() {
+    return jmsContext.createMapMessage();
+  }
+
+  @Override
+  public Message createMessage() {
+    return jmsContext.createMessage();
+  }
+
+  @Override
+  public ObjectMessage createObjectMessage() {
+    return jmsContext.createObjectMessage();
+  }
+
+  @Override
+  public ObjectMessage createObjectMessage(Serializable object) {
+    return jmsContext.createObjectMessage(object);
+  }
+
+  @Override
+  public StreamMessage createStreamMessage() {
+    return jmsContext.createStreamMessage();
+  }
+
+  @Override
+  public TextMessage createTextMessage() {
+    return jmsContext.createTextMessage();
+  }
+
+  @Override
+  public TextMessage createTextMessage(String text) {
+    return jmsContext.createTextMessage(text);
+  }
+
+  @Override
+  public boolean getTransacted() {
+    return jmsContext.getTransacted();
+  }
+
+  @Override
+  public int getSessionMode() {
+    return jmsContext.getSessionMode();
+  }
+
+  @Override
+  public void commit() {
+    jmsContext.commit();
+  }
+
+  @Override
+  public void rollback() {
+    jmsContext.rollback();
+  }
+
+  @Override
+  public void recover() {
+    jmsContext.recover();
+  }
+
+  @Override
+  public JMSConsumer createConsumer(Destination destination) {
+    return new TracingJMSConsumer(jmsContext.createConsumer(destination), tracer);
+  }
+
+  @Override
+  public JMSConsumer createConsumer(Destination destination, String messageSelector) {
+    return new TracingJMSConsumer(jmsContext.createConsumer(destination, messageSelector), tracer);
+  }
+
+  @Override
+  public JMSConsumer createConsumer(Destination destination, String messageSelector, boolean noLocal) {
+    return new TracingJMSConsumer(jmsContext.createConsumer(destination, messageSelector, noLocal), tracer);
+  }
+
+  @Override
+  public Queue createQueue(String queueName) {
+    return jmsContext.createQueue(queueName);
+  }
+
+  @Override
+  public Topic createTopic(String topicName) {
+    return jmsContext.createTopic(topicName);
+  }
+
+  @Override
+  public JMSConsumer createDurableConsumer(Topic topic, String name) {
+    return new TracingJMSConsumer(jmsContext.createDurableConsumer(topic, name), tracer);
+  }
+
+  @Override
+  public JMSConsumer createDurableConsumer(Topic topic, String name, String messageSelector, boolean noLocal) {
+    return new TracingJMSConsumer(jmsContext.createDurableConsumer(topic, name, messageSelector, noLocal), tracer);
+  }
+
+  @Override
+  public JMSConsumer createSharedDurableConsumer(Topic topic, String name) {
+    return new TracingJMSConsumer(jmsContext.createSharedDurableConsumer(topic, name), tracer);
+  }
+
+  @Override
+  public JMSConsumer createSharedDurableConsumer(Topic topic, String name, String messageSelector) {
+    return new TracingJMSConsumer(jmsContext.createSharedDurableConsumer(topic, name, messageSelector), tracer);
+  }
+
+  @Override
+  public JMSConsumer createSharedConsumer(Topic topic, String sharedSubscriptionName) {
+    return new TracingJMSConsumer(jmsContext.createSharedConsumer(topic, sharedSubscriptionName), tracer);
+  }
+
+  @Override
+  public JMSConsumer createSharedConsumer(Topic topic, String sharedSubscriptionName, String messageSelector) {
+    return new TracingJMSConsumer(jmsContext.createSharedConsumer(topic, sharedSubscriptionName, messageSelector),
+            tracer);
+  }
+
+  @Override
+  public QueueBrowser createBrowser(Queue queue) {
+    return jmsContext.createBrowser(queue);
+  }
+
+  @Override
+  public QueueBrowser createBrowser(Queue queue, String messageSelector) {
+    return jmsContext.createBrowser(queue, messageSelector);
+  }
+
+  @Override
+  public TemporaryQueue createTemporaryQueue() {
+    return jmsContext.createTemporaryQueue();
+  }
+
+  @Override
+  public TemporaryTopic createTemporaryTopic() {
+    return jmsContext.createTemporaryTopic();
+  }
+
+  @Override
+  public void unsubscribe(String name) {
+    jmsContext.unsubscribe(name);
+  }
+
+  @Override
+  public void acknowledge() {
+    jmsContext.acknowledge();
+  }
+}

--- a/opentracing-jms-2/src/test/java/io/opentracing/contrib/jms2/TracingArtemisViaConnectionFactoryTest.java
+++ b/opentracing-jms-2/src/test/java/io/opentracing/contrib/jms2/TracingArtemisViaConnectionFactoryTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.jms2;
+
+import io.opentracing.contrib.jms.common.TracingMessageUtils;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.remoting.impl.invm.InVMAcceptorFactory;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
+import org.apache.activemq.artemis.jms.client.ActiveMQJMSConnectionFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+import javax.jms.JMSProducer;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class TracingArtemisViaConnectionFactoryTest {
+
+  private final MockTracer mockTracer = new MockTracer();
+
+  private ActiveMQServer server;
+  private Connection connection;
+  private Session session;
+  private JMSContext jmsContext;
+
+  @Before
+  public void before() throws Exception {
+    mockTracer.reset();
+
+    Configuration configuration = new ConfigurationImpl();
+
+    HashSet<TransportConfiguration> transports = new HashSet<>();
+    transports.add(new TransportConfiguration(InVMAcceptorFactory.class.getName()));
+    configuration.setAcceptorConfigurations(transports);
+    configuration.setSecurityEnabled(false);
+
+    File targetDir = new File(System.getProperty("user.dir") + "/target");
+    configuration.setBrokerInstance(targetDir);
+
+    server = new ActiveMQServerImpl(configuration);
+    server.start();
+
+    ConnectionFactory activeMQJMSConnectionFactory = new ActiveMQJMSConnectionFactory("vm://0");
+    ConnectionFactory tracingConnectionFactory = new TracingConnectionFactory(activeMQJMSConnectionFactory, mockTracer);
+    connection = tracingConnectionFactory.createConnection();
+    connection.start();
+
+    session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+    jmsContext = tracingConnectionFactory.createContext();
+  }
+
+  @After
+  public void after() throws Exception {
+    jmsContext.close();
+    session.close();
+    connection.close();
+    server.stop();
+  }
+
+  @Test
+  public void sendAndReceive() throws Exception {
+    Queue queue = session.createQueue("TEST.FOO");
+    MessageProducer producer = session.createProducer(queue);
+    MessageConsumer consumer = session.createConsumer(queue);
+    TextMessage message = session.createTextMessage("Hello world");
+
+    producer.send(message);
+
+    TextMessage received = (TextMessage) consumer.receive(5000);
+    assertEquals("Hello world", received.getText());
+
+    List<MockSpan> mockSpans = mockTracer.finishedSpans();
+    assertEquals(2, mockSpans.size());
+
+    checkSpans(mockSpans);
+    assertNull(mockTracer.activeSpan());
+  }
+
+  @Test
+  public void sendAndReceiveJMSProducer() throws Exception {
+    Destination destination = session.createQueue("TEST.FOO");
+    JMSProducer producer = jmsContext.createProducer();
+    MessageConsumer consumer = session.createConsumer(destination);
+    TextMessage message = session.createTextMessage("Hello world");
+
+    producer.send(destination, message);
+
+    TextMessage received = (TextMessage) consumer.receive(5000);
+    assertEquals("Hello world", received.getText());
+
+    List<MockSpan> mockSpans = mockTracer.finishedSpans();
+    assertEquals(2, mockSpans.size());
+
+    checkSpans(mockSpans);
+    assertNull(mockTracer.activeSpan());
+  }
+
+  @Test
+  public void sendAndReceiveInListener() throws Exception {
+    Destination destination = session.createQueue("TEST.FOO");
+    MessageProducer producer = session.createProducer(destination);
+    MessageConsumer consumer = session.createConsumer(destination);
+
+    final CountDownLatch countDownLatch = new CountDownLatch(1);
+    MessageListener listener = new MessageListener() {
+      @Override
+      public void onMessage(Message message) {
+        countDownLatch.countDown();
+      }
+    };
+    consumer.setMessageListener(listener);
+
+    TextMessage message = session.createTextMessage("Hello world");
+
+    producer.send(message);
+    countDownLatch.await(15, TimeUnit.SECONDS);
+
+    await().atMost(15, TimeUnit.SECONDS).until(reportedSpansSize(), equalTo(2));
+
+    List<MockSpan> mockSpans = mockTracer.finishedSpans();
+    assertEquals(2, mockSpans.size());
+
+    checkSpans(mockSpans);
+
+    assertNull(mockTracer.activeSpan());
+  }
+
+  private void checkSpans(List<MockSpan> mockSpans) {
+    for (MockSpan mockSpan : mockSpans) {
+      assertTrue(mockSpan.tags().get(Tags.SPAN_KIND.getKey()).equals(Tags.SPAN_KIND_CONSUMER)
+              || mockSpan.tags().get(Tags.SPAN_KIND.getKey()).equals(Tags.SPAN_KIND_PRODUCER));
+      assertEquals(TracingMessageUtils.COMPONENT_NAME,
+              mockSpan.tags().get(Tags.COMPONENT.getKey()));
+      assertEquals(0, mockSpan.generatedErrors().size());
+      String operationName = mockSpan.operationName();
+      assertTrue(operationName.equals(TracingMessageUtils.OPERATION_NAME_SEND)
+              || operationName.equals(TracingMessageUtils.OPERATION_NAME_RECEIVE));
+    }
+  }
+
+  private Callable<Integer> reportedSpansSize() {
+    return new Callable<Integer>() {
+      @Override
+      public Integer call() {
+        return mockTracer.finishedSpans().size();
+      }
+    };
+  }
+}


### PR DESCRIPTION
Add `TracingConnectionFactory`, `TracingJMSContext` and `TracingJMSConsumer` (#39).

I didn't add checking for double wrapping (e.g. `TracingJmsTemplate` which uses `TracingConnectionFactory`). If everything configured properly, it shouldn't be a case.