### PR TITLE
Use separated operation name for message listeners and do minor refactoring for TracingMessageUtils

### DIFF
--- a/opentracing-jms-1/src/main/java/io/opentracing/contrib/jms/TracingMessageProducer.java
+++ b/opentracing-jms-1/src/main/java/io/opentracing/contrib/jms/TracingMessageProducer.java
@@ -98,7 +98,7 @@ public class TracingMessageProducer implements MessageProducer {
 
   @Override
   public void send(Message message) throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(getDestination(), message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(getDestination(), message, tracer);
     try {
       messageProducer.send(message);
     } catch (Throwable e) {
@@ -112,7 +112,7 @@ public class TracingMessageProducer implements MessageProducer {
   @Override
   public void send(Message message, int deliveryMode, int priority, long timeToLive)
       throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(getDestination(), message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(getDestination(), message, tracer);
     try {
       messageProducer.send(message, deliveryMode, priority, timeToLive);
     } catch (Throwable e) {
@@ -125,7 +125,7 @@ public class TracingMessageProducer implements MessageProducer {
 
   @Override
   public void send(Destination destination, Message message) throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(destination, message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(destination, message, tracer);
     try {
       messageProducer.send(destination, message);
     } catch (Throwable e) {
@@ -139,7 +139,7 @@ public class TracingMessageProducer implements MessageProducer {
   @Override
   public void send(Destination destination, Message message, int deliveryMode, int priority,
       long timeToLive) throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(destination, message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(destination, message, tracer);
     try {
       messageProducer.send(destination, message, deliveryMode, priority, timeToLive);
     } catch (Throwable e) {

--- a/opentracing-jms-1/src/test/java/io/opentracing/contrib/jms/TracingActiveMQTest.java
+++ b/opentracing-jms-1/src/test/java/io/opentracing/contrib/jms/TracingActiveMQTest.java
@@ -218,7 +218,8 @@ public class TracingActiveMQTest {
       assertEquals(0, mockSpan.generatedErrors().size());
       String operationName = mockSpan.operationName();
       assertTrue(operationName.equals(TracingMessageUtils.OPERATION_NAME_SEND)
-          || operationName.equals(TracingMessageUtils.OPERATION_NAME_RECEIVE));
+          || operationName.equals(TracingMessageUtils.OPERATION_NAME_RECEIVE)
+          || operationName.equals(TracingMessageUtils.OPERATION_NAME_ON_MESSAGE));
     }
   }
 

--- a/opentracing-jms-2/src/main/java/io/opentracing/contrib/jms2/TracingJMSProducer.java
+++ b/opentracing-jms-2/src/main/java/io/opentracing/contrib/jms2/TracingJMSProducer.java
@@ -173,7 +173,7 @@ public class TracingJMSProducer implements JMSProducer {
 
   @Override
   public JMSProducer send(Destination destination, Message message) {
-    Span span = TracingMessageUtils.buildAndInjectSpan(destination, message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(destination, message, tracer);
     try {
       jmsProducer.send(destination, message);
     } catch (Throwable e) {

--- a/opentracing-jms-2/src/main/java/io/opentracing/contrib/jms2/TracingMessageProducer.java
+++ b/opentracing-jms-2/src/main/java/io/opentracing/contrib/jms2/TracingMessageProducer.java
@@ -109,7 +109,7 @@ public class TracingMessageProducer implements MessageProducer {
 
   @Override
   public void send(Message message) throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(getDestination(), message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(getDestination(), message, tracer);
     try {
       messageProducer.send(message);
     } catch (Throwable e) {
@@ -124,7 +124,7 @@ public class TracingMessageProducer implements MessageProducer {
   @Override
   public void send(Message message, int deliveryMode, int priority, long timeToLive)
       throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(getDestination(), message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(getDestination(), message, tracer);
     try {
       messageProducer.send(message, deliveryMode, priority, timeToLive);
     } catch (Throwable e) {
@@ -137,7 +137,7 @@ public class TracingMessageProducer implements MessageProducer {
 
   @Override
   public void send(Destination destination, Message message) throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(destination, message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(destination, message, tracer);
     try {
       messageProducer.send(destination, message);
     } catch (Throwable e) {
@@ -151,7 +151,7 @@ public class TracingMessageProducer implements MessageProducer {
   @Override
   public void send(Destination destination, Message message, int deliveryMode, int priority,
       long timeToLive) throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(destination, message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(destination, message, tracer);
     try {
       messageProducer.send(destination, message, deliveryMode, priority, timeToLive);
     } catch (Throwable e) {
@@ -164,14 +164,14 @@ public class TracingMessageProducer implements MessageProducer {
 
   @Override
   public void send(Message message, CompletionListener completionListener) throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(getDestination(), message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(getDestination(), message, tracer);
     messageProducer.send(message, new TracingCompletionListener(span, completionListener));
   }
 
   @Override
   public void send(Message message, int deliveryMode, int priority, long timeToLive,
       CompletionListener completionListener) throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(getDestination(), message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(getDestination(), message, tracer);
     messageProducer.send(message, deliveryMode, priority, timeToLive,
         new TracingCompletionListener(span, completionListener));
   }
@@ -179,7 +179,7 @@ public class TracingMessageProducer implements MessageProducer {
   @Override
   public void send(Destination destination, Message message, CompletionListener completionListener)
       throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(destination, message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(destination, message, tracer);
     messageProducer.send(destination, message,
         new TracingCompletionListener(span, completionListener));
   }
@@ -187,7 +187,7 @@ public class TracingMessageProducer implements MessageProducer {
   @Override
   public void send(Destination destination, Message message, int deliveryMode, int priority,
       long timeToLive, CompletionListener completionListener) throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(destination, message, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(destination, message, tracer);
     messageProducer.send(destination, message, deliveryMode, priority, timeToLive,
         new TracingCompletionListener(span, completionListener));
   }

--- a/opentracing-jms-2/src/test/java/io/opentracing/contrib/jms2/TracingArtemisTest.java
+++ b/opentracing-jms-2/src/test/java/io/opentracing/contrib/jms2/TracingArtemisTest.java
@@ -233,7 +233,8 @@ public class TracingArtemisTest {
       assertEquals(0, mockSpan.generatedErrors().size());
       String operationName = mockSpan.operationName();
       assertTrue(operationName.equals(TracingMessageUtils.OPERATION_NAME_SEND)
-          || operationName.equals(TracingMessageUtils.OPERATION_NAME_RECEIVE));
+          || operationName.equals(TracingMessageUtils.OPERATION_NAME_RECEIVE)
+          || operationName.equals(TracingMessageUtils.OPERATION_NAME_ON_MESSAGE));
     }
   }
 

--- a/opentracing-jms-2/src/test/java/io/opentracing/contrib/jms2/TracingArtemisViaConnectionFactoryTest.java
+++ b/opentracing-jms-2/src/test/java/io/opentracing/contrib/jms2/TracingArtemisViaConnectionFactoryTest.java
@@ -174,7 +174,8 @@ public class TracingArtemisViaConnectionFactoryTest {
       assertEquals(0, mockSpan.generatedErrors().size());
       String operationName = mockSpan.operationName();
       assertTrue(operationName.equals(TracingMessageUtils.OPERATION_NAME_SEND)
-              || operationName.equals(TracingMessageUtils.OPERATION_NAME_RECEIVE));
+              || operationName.equals(TracingMessageUtils.OPERATION_NAME_RECEIVE)
+              || operationName.equals(TracingMessageUtils.OPERATION_NAME_ON_MESSAGE));
     }
   }
 

--- a/opentracing-jms-common/src/main/java/io/opentracing/contrib/jms/common/TracingMessageConsumer.java
+++ b/opentracing-jms-common/src/main/java/io/opentracing/contrib/jms/common/TracingMessageConsumer.java
@@ -73,9 +73,9 @@ public class TracingMessageConsumer implements MessageConsumer {
   public Message receive() throws JMSException {
     Message message = messageConsumer.receive();
     if (proxyMessage) {
-      return proxy(message, finishSpan(message));
+      return proxy(message, startAndFinishConsumerSpan(message));
     }
-    finishSpan(message);
+    startAndFinishConsumerSpan(message);
     return message;
   }
 
@@ -83,9 +83,9 @@ public class TracingMessageConsumer implements MessageConsumer {
   public Message receive(long timeout) throws JMSException {
     Message message = messageConsumer.receive(timeout);
     if (proxyMessage) {
-      return proxy(message, finishSpan(message));
+      return proxy(message, startAndFinishConsumerSpan(message));
     }
-    finishSpan(message);
+    startAndFinishConsumerSpan(message);
     return message;
   }
 
@@ -93,9 +93,9 @@ public class TracingMessageConsumer implements MessageConsumer {
   public Message receiveNoWait() throws JMSException {
     Message message = messageConsumer.receiveNoWait();
     if (proxyMessage) {
-      return proxy(message, finishSpan(message));
+      return proxy(message, startAndFinishConsumerSpan(message));
     }
-    finishSpan(message);
+    startAndFinishConsumerSpan(message);
     return message;
   }
 
@@ -104,8 +104,8 @@ public class TracingMessageConsumer implements MessageConsumer {
     messageConsumer.close();
   }
 
-  private SpanContext finishSpan(Message message) {
-    return TracingMessageUtils.buildAndFinishChildSpan(message, tracer);
+  private SpanContext startAndFinishConsumerSpan(Message message) {
+    return TracingMessageUtils.startAndFinishConsumerSpan(message, tracer);
   }
 
   private Message proxy(final Message message, final SpanContext spanContext) {

--- a/opentracing-jms-common/src/main/java/io/opentracing/contrib/jms/common/TracingMessageListener.java
+++ b/opentracing-jms-common/src/main/java/io/opentracing/contrib/jms/common/TracingMessageListener.java
@@ -42,7 +42,7 @@ public class TracingMessageListener implements MessageListener {
 
   @Override
   public void onMessage(Message message) {
-    Span span = TracingMessageUtils.buildFollowingSpan(message, tracer);
+    Span span = TracingMessageUtils.startListenerSpan(message, tracer);
     if (traceInLog) {
       if (span != null) {
         MDC.put("spanId", span.context().toSpanId());

--- a/opentracing-jms-common/src/main/java/io/opentracing/contrib/jms/common/TracingMessageUtils.java
+++ b/opentracing-jms-common/src/main/java/io/opentracing/contrib/jms/common/TracingMessageUtils.java
@@ -13,110 +13,113 @@
  */
 package io.opentracing.contrib.jms.common;
 
-
 import io.opentracing.References;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
 import io.opentracing.tag.Tags;
+
 import javax.jms.Destination;
 import javax.jms.Message;
 
 public class TracingMessageUtils {
 
+  public static final String COMPONENT_NAME = "java-jms";
   public static final String OPERATION_NAME_SEND = "jms-send";
   public static final String OPERATION_NAME_RECEIVE = "jms-receive";
-  public static final String COMPONENT_NAME = "java-jms";
+  public static final String OPERATION_NAME_ON_MESSAGE = "jms-on-message";
 
   /**
-   * Build following span and finish it. Should be used by consumers/listeners
+   * Start message consumer {@code span} and finish it.
    *
-   * @param message JMS message
-   * @param tracer Tracer
-   * @return child span context
+   * @param message the JMS message
+   * @param tracer  the tracer
+   * @return the span context
    */
-  public static SpanContext buildAndFinishChildSpan(Message message, Tracer tracer) {
+  public static SpanContext startAndFinishConsumerSpan(Message message, Tracer tracer) {
     if (message == null) {
       return null;
     }
-    Span child = buildFollowingSpan(message, tracer);
-    child.finish();
-    return child.context();
+    Span span = startConsumerSpan(message, tracer, OPERATION_NAME_RECEIVE);
+    span.finish();
+    return span.context();
   }
 
   /**
-   * It is used by consumers only
+   * Start message listener {@code span}.
+   *
+   * @param message the JMS message
+   * @param tracer  the tracer
+   * @return the span
    */
-  public static Span buildFollowingSpan(Message message, Tracer tracer) {
+  public static Span startListenerSpan(Message message, Tracer tracer) {
+    return startConsumerSpan(message, tracer, OPERATION_NAME_ON_MESSAGE);
+  }
+
+  /**
+   * Extract {@code spanContext} from the {@code message} or an active {@code span}.
+   *
+   * @param message the JMS message
+   * @param tracer  the tracer
+   * @return an extracted span context
+   */
+  public static SpanContext extract(Message message, Tracer tracer) {
+    SpanContext context = tracer.extract(Format.Builtin.TEXT_MAP, new JmsTextMapExtractAdapter(message));
+    if (context != null && context.toTraceId() != null && context.toSpanId() != null) {
+      return context;
+    }
+    Span span = tracer.activeSpan();
+    return span != null ? span.context() : null;
+  }
+
+  /**
+   * Start message producer {@code span} and inject {@code spanContext} into the {@code message}.
+   *
+   * @param destination the destination
+   * @param message     the JMS message
+   * @param tracer      the tracer
+   * @return the span
+   */
+  public static Span startAndInjectSpan(Destination destination, Message message, Tracer tracer) {
     SpanContext context = extract(message, tracer);
-
-    Tracer.SpanBuilder spanBuilder = tracer.buildSpan(OPERATION_NAME_RECEIVE).ignoreActiveSpan()
-        .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CONSUMER);
-
-    // if context is null this is a no-op
-    spanBuilder.addReference(References.FOLLOWS_FROM, context);
-
-    Span span = spanBuilder.start();
-
-    SpanJmsDecorator.onResponse(message, span);
-
+    Span span = tracer.buildSpan(TracingMessageUtils.OPERATION_NAME_SEND)
+            .ignoreActiveSpan()
+            .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER)
+            .asChildOf(context)
+            .start();
+    SpanJmsDecorator.onRequest(destination, span);
+    inject(span, message, tracer);
     return span;
   }
 
   /**
-   * Extract span context from JMS message properties or active span
+   * Inject {@code spanContext} into the {@code message}.
    *
-   * @param message JMS message
-   * @param tracer Tracer
-   * @return extracted span context
-   */
-  public static SpanContext extract(Message message, Tracer tracer) {
-    SpanContext spanContext =
-        tracer.extract(Format.Builtin.TEXT_MAP, new JmsTextMapExtractAdapter(message));
-    if (spanContext != null && spanContext.toTraceId() != null && spanContext.toSpanId() != null) {
-      return spanContext;
-    }
-
-    Span span = tracer.activeSpan();
-    if (span != null) {
-      return span.context();
-    }
-    return null;
-  }
-
-  /**
-   * Inject span context to JMS message properties
-   *
-   * @param span span
-   * @param message JMS message
+   * @param span    the span
+   * @param message the JMS message
+   * @param tracer  the tracer
    */
   public static void inject(Span span, Message message, Tracer tracer) {
     tracer.inject(span.context(), Format.Builtin.TEXT_MAP, new JmsTextMapInjectAdapter(message));
   }
 
   /**
-   * Build span and inject. Should be used by producers.
+   * Start message consumer {@code span} with {@code FollowsFrom} reference type.
    *
-   * @param message JMS message
-   * @return span
+   * @param message       the JMS message
+   * @param tracer        the tracer
+   * @param operationName the operation name
+   * @return the span
    */
-  public static Span buildAndInjectSpan(Destination destination, final Message message,
-      Tracer tracer) {
-    Tracer.SpanBuilder spanBuilder = tracer.buildSpan(TracingMessageUtils.OPERATION_NAME_SEND)
-        .ignoreActiveSpan().withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER);
-
-    SpanContext parent = TracingMessageUtils.extract(message, tracer);
-
-    if (parent != null) {
-      spanBuilder.asChildOf(parent);
-    }
-
-    Span span = spanBuilder.start();
-
-    SpanJmsDecorator.onRequest(destination, span);
-
-    TracingMessageUtils.inject(span, message, tracer);
+  private static Span startConsumerSpan(Message message, Tracer tracer, String operationName) {
+    SpanContext context = extract(message, tracer);
+    Span span = tracer.buildSpan(operationName)
+            .ignoreActiveSpan()
+            .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CONSUMER)
+            .addReference(References.FOLLOWS_FROM, context)
+            .start();
+    SpanJmsDecorator.onResponse(message, span);
     return span;
   }
 }

--- a/opentracing-jms-spring/src/main/java/io/opentracing/contrib/jms/spring/TracingMessagingMessageListenerAdapter.java
+++ b/opentracing-jms-spring/src/main/java/io/opentracing/contrib/jms/spring/TracingMessagingMessageListenerAdapter.java
@@ -60,7 +60,7 @@ public class TracingMessagingMessageListenerAdapter extends MessagingMessageList
   @Override
   protected void sendResponse(Session session, Destination destination, Message response)
       throws JMSException {
-    Span span = TracingMessageUtils.buildAndInjectSpan(destination, response, tracer);
+    Span span = TracingMessageUtils.startAndInjectSpan(destination, response, tracer);
     try {
       super.sendResponse(session, destination, response);
     } finally {

--- a/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/TracingJmsTemplateTest.java
+++ b/opentracing-jms-spring/src/test/java/io/opentracing/contrib/jms/spring/TracingJmsTemplateTest.java
@@ -142,7 +142,8 @@ public class TracingJmsTemplateTest {
       assertEquals(0, mockSpan.generatedErrors().size());
       String operationName = mockSpan.operationName();
       assertTrue(operationName.equals(TracingMessageUtils.OPERATION_NAME_SEND)
-          || operationName.equals(TracingMessageUtils.OPERATION_NAME_RECEIVE));
+          || operationName.equals(TracingMessageUtils.OPERATION_NAME_RECEIVE)
+          || operationName.equals(TracingMessageUtils.OPERATION_NAME_ON_MESSAGE));
     }
   }
 


### PR DESCRIPTION
Use separated operation name for message listeners and do minor refactoring for `TracingMessageUtils` (#41).

Before:

![Spans](https://user-images.githubusercontent.com/3935276/91914951-99b37000-ecb9-11ea-9263-f0a9890d3df0.png)

After:

![Spans](https://user-images.githubusercontent.com/3935276/92238270-28421000-eeb9-11ea-92d0-1c463f9dab17.png)