### PR TITLE
Change $ to _ in DASH replace string

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ is necessary to encode the trace context and baggage item names.
 
 The steps used to encode the key names are:
 
-- replace any `-` character with `_$dash$_`
+- replace any `-` character with `__dash__`
 
 When the message is consumed, the steps are reversed to decode the original key names.
 

--- a/opentracing-jms-common/src/main/java/io/opentracing/contrib/jms/common/JmsTextMapInjectAdapter.java
+++ b/opentracing-jms-common/src/main/java/io/opentracing/contrib/jms/common/JmsTextMapInjectAdapter.java
@@ -24,7 +24,7 @@ import javax.jms.Message;
  */
 public class JmsTextMapInjectAdapter implements TextMap {
 
-  static final String DASH = "_$dash$_";
+  static final String DASH = "__dash__";
   private final Message message;
 
   public JmsTextMapInjectAdapter(Message message) {


### PR DESCRIPTION
When using SQS as a JMS backend the  JmsTextMapInjectAdapter produces a SQSMessage which is rejected by SQS service. [As per SQS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html#message-attribute-components):

> The message attribute name can contain the following characters: A-Z, a-z, 0-9, underscore (_), hyphen (-), and period (.). The following restrictions apply:

I think it's safe to change the "-" replacement a bit and remove "$".
